### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/block.php
+++ b/syntax/block.php
@@ -42,7 +42,7 @@ class syntax_plugin_codedoc_block extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addExitPattern('</codetoggle>','plugin_codedoc_block');
     }
  
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
 
         switch ($state) {
 
@@ -62,7 +62,7 @@ class syntax_plugin_codedoc_block extends DokuWiki_Syntax_Plugin {
         }
     }
  
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
 
         if($mode == 'xhtml'){
 

--- a/syntax/specials.php
+++ b/syntax/specials.php
@@ -34,7 +34,7 @@ class syntax_plugin_codedoc_specials extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('~~codedoc:.*?~~',$mode,'plugin_codedoc_specials');
     }
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         $match = trim(substr($match,10,-2));   
         $type = strtolower($match); 
         if(trim($type) == 'timestamp') {  
@@ -43,7 +43,7 @@ class syntax_plugin_codedoc_specials extends DokuWiki_Syntax_Plugin {
         return array($match,$state);
     }
     
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
        global $ID;
         if($mode == 'xhtml'){
             list($match, $state) = $data;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
